### PR TITLE
Add geometric-pattern-app React project

### DIFF
--- a/geometric-pattern-app/.gitignore
+++ b/geometric-pattern-app/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/geometric-pattern-app/index.html
+++ b/geometric-pattern-app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Geometric Pattern</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/geometric-pattern-app/package.json
+++ b/geometric-pattern-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "geometric-pattern-app",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/geometric-pattern-app/src/App.jsx
+++ b/geometric-pattern-app/src/App.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import MinimalPattern from './MinimalPattern';
+
+export default function App() {
+  return <MinimalPattern />;
+}

--- a/geometric-pattern-app/src/MinimalPattern.jsx
+++ b/geometric-pattern-app/src/MinimalPattern.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const containerStyle = {
+  width: '100vw',
+  height: '100vh',
+  margin: 0,
+  backgroundImage: `repeating-linear-gradient(45deg, #444 0, #444 10px, #222 10px, #222 20px)`,
+};
+
+export default function MinimalPattern() {
+  return <div style={containerStyle} />;
+}

--- a/geometric-pattern-app/src/main.jsx
+++ b/geometric-pattern-app/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/geometric-pattern-app/vite.config.js
+++ b/geometric-pattern-app/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- add `geometric-pattern-app` created manually with Vite configuration
- scaffold React files with MinimalPattern component rendering a simple repeating linear gradient pattern
- configure Vite server for port 3000

## Testing
- `npm test` *(fails: Error: no test specified)*