### PR TITLE
Add GitHub Pages deploy for geometric-pattern-app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy Geometric Pattern App
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+        working-directory: geometric-pattern-app
+      - name: Build
+        run: npm run build
+        working-directory: geometric-pattern-app
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: geometric-pattern-app/dist
+          publish_branch: gh-pages
+

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ git push heroku main
 Create a new app and point it to your GitHub repository.
 Set the run command to: `npm run serve`
 
+#### GitHub Pages
+The `geometric-pattern-app` can be deployed to GitHub Pages.
+
+```bash
+cd geometric-pattern-app
+npm run deploy
+```
+
+After deployment, visit `https://<your-username>.github.io/geometric-pattern-app/` to view the live site.
+
 ## License
 
 MIT License

--- a/geometric-pattern-app/package.json
+++ b/geometric-pattern-app/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -13,6 +15,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "gh-pages": "^6.0.0"
   }
 }

--- a/geometric-pattern-app/vite.config.js
+++ b/geometric-pattern-app/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/geometric-pattern-app/',
   plugins: [react()],
   server: {
     port: 3000


### PR DESCRIPTION
## Summary
- add gh-pages scripts and dependency to geometric-pattern-app
- set Vite base path for GitHub Pages
- create GitHub Actions workflow for deploying to gh-pages
- document how to deploy geometric-pattern-app via GitHub Pages

## Testing
- `npm run build` *(fails: vite not found)*